### PR TITLE
SHARE ROW EXCLUSIVE lock mode in sequence generation

### DIFF
--- a/invoicing/querysets.py
+++ b/invoicing/querysets.py
@@ -62,7 +62,7 @@ class InvoiceQuerySet(QuerySet):
         """
         cursor = connection.cursor()
         table = self.model._meta.db_table
-        cursor.execute("LOCK TABLE %s" % table)
+        cursor.execute("LOCK TABLE %s IN SHARE ROW EXCLUSIVE MODE" % table)
 
 
 class ItemQuerySet(QuerySet):


### PR DESCRIPTION
Improved performance during new sequence generation by choosing a less restrictive lock mode, avoiding the blocking of other SELECT operations outside this transaction.